### PR TITLE
Fix for Microarchitecture

### DIFF
--- a/src/serialization-map.json
+++ b/src/serialization-map.json
@@ -5,7 +5,8 @@
 		"Performance Core Boost Clock": ["boost_clock", true],
 		"TDP": ["tdp", true],
 		"Integrated Graphics": ["graphics", false],
-		"SMT": ["smt", false]
+		"SMT": ["smt", false],
+		"Microarchitecture": ["microarchitecture", false]
 	},
 	"cpu-cooler": {
 		"Fan RPM": ["rpm", true],


### PR DESCRIPTION
PCPartPicker added "Microarchitecture" to the CPU's values, which caused the program to abort. Adding "Microarchitecture" to the serialization-map.json should fix this issue.